### PR TITLE
"For example, a store may be buffered in a cache that later writes."

### DIFF
--- a/cmobase/background.adoc
+++ b/cmobase/background.adoc
@@ -28,7 +28,7 @@ update) the data at the physical resource.
 _Load and store operations are decoupled from read and write operations by
 caches, described below. For example, a load operation may be satisfied by a
 cache without performing a read operation in memory, or a store operation may be
-satisfied by a cache that first performs a read operation._
+buffered in a cache that later performs a write operation._
 
 ****
 


### PR DESCRIPTION
**Type of change**: Clarification.

**Explanation**:
1. The intent of the example (if I'm reading between the lines correctly) is that stores may buffer in a cache to later write, not that stores trigger reads.
2. A store to a cache need not necessarily be satisfied by a read operation to fill the cache, if the cache tracks data valid / dirty at a small enough granule and/or gathers enough stores to fill a data valid / dirty granule.