### PR TITLE
Constrained LR/SC Loops: prohibit CBO.CLEAN

### DIFF
--- a/cmobase/background.adoc
+++ b/cmobase/background.adoc
@@ -301,8 +301,8 @@ should program the NAPOT range to equal the cache block size._
 
 === Effects on Constrained LR/SC Loops
 
-Executing a `CBO.INVAL`, `CBO.FLUSH`, `CBO.ZERO`, or `PREFETCH.W` instruction
-may cause a reservation on another hart to be lost. As a result, executing one
-of these instructions constitutes an additional event (like executing an
-unconditional store or AMO instruction) that satisfies the system forward
-progress requirements of constrained LR/SC loops.
+Executing a `CBO.INVAL`, `CBO.FLUSH`, `CBO.CLEAN`, `CBO.ZERO`, or `PREFETCH.W`
+instruction may cause a reservation on another hart to be lost. As a result,
+executing one of these instructions constitutes an additional event (like
+executing an unconditional store or AMO instruction) that satisfies the
+system forward progress requirements of constrained LR/SC loops.


### PR DESCRIPTION
**Type of change**: Software constraint.

**Explanation**:
It seems safer and easier to just prohibit CBO.CLEAN as well to an address covered by the LR/SC reservation, rather than think through all the corner cases and chicken modes that would need to be handled if it were allowed.