### PR TITLE
Minor specification language change proposals on cmobase-0.5

### DIFF
--- a/cmobase/Zicboz.adoc
+++ b/cmobase/Zicboz.adoc
@@ -5,6 +5,10 @@ Cache block zero instructions perform a series of byte-sized store operations
 where the data are zero. An implementation may or may not update the entire
 cache block atomically.
 
+The cache block zero instructions can operate even if the target memory
+locations are not served by a cache, or if the memory locations are defined to
+be uncacheable.
+
 The following instructions comprise the Zicboz extension:
 
 [%header,cols="^1,^1,4,8"]

--- a/cmobase/Zicboz.adoc
+++ b/cmobase/Zicboz.adoc
@@ -1,9 +1,9 @@
 [#Zicboz,reftext="Cache Block Zero Instructions"]
 === Cache Block Zero Instructions
 
-Cache block zero instructions perform a series of byte-sized store operations
-where the data are zero. An implementation may or may not update the entire
-cache block atomically.
+Cache block zero instructions function as if a series of byte-sized (or larger)
+store operations are issued in which the data are zero.  An implementation may
+or may not update the entire cache block atomically.
 
 The cache block zero instructions can operate even if the target memory
 locations are not served by a cache, or if the memory locations are defined to

--- a/cmobase/background.adoc
+++ b/cmobase/background.adoc
@@ -407,6 +407,7 @@ periodic cancellation of a reservation on another hart._
 * cache block size for management and prefetch
 * cache block size for zero
 * CBIE support at each privilege level
+* what happens if CBO operations are executed on addresses that are not cached?
 
 At minimum, the configuration structure needs to describe the two cache block
 sizes and the supported CBIE values.

--- a/cmobase/background.adoc
+++ b/cmobase/background.adoc
@@ -7,17 +7,16 @@ This chapter provides information common to all CMO extensions.
 
 A _memory location_ is a physical resource in a system uniquely identified by a
 _physical address_. The _observers_ of a given memory location consist of the
-RISC-V harts or I/O devices that can access that memory location. A given
-observer may not be able to access all memory locations in a system, and two
-different harts or devices may or may not be able to observe the same set of
-memory locations.
+bus initiators that can access that memory location. A given observer may not
+be able to access all memory locations in a system, and two different observers
+may or may not be able to observe the same set of memory locations.
 
 In this specification, a _load operation_ (or _store operation_) is performed by
-an observer to consume (or modify) the data at a given memory location. For a
-RISC-V hart, a load or store operation may be performed as a result of an
-explicit or implicit memory access. Additionally, a _read operation_ (or _write
-operation_) is an operation performed on the memory location to fetch (or
-update) the data at the physical resource.
+an observer to consume (or modify) the data at a given memory location. Load or
+store operations may be performed as a result of explicit or implicit memory
+accesses. Additionally, a _read operation_ (or _write operation_) is an
+operation performed on the memory location to fetch (or update) the data at the
+physical resource.
 
 ****
 

--- a/cmobase/background.adoc
+++ b/cmobase/background.adoc
@@ -408,6 +408,9 @@ periodic cancellation of a reservation on another hart._
 * cache block size for zero
 * CBIE support at each privilege level
 * what happens if CBO operations are executed on addresses that are not cached?
+* physical addresses may differ between observers (remapping mechanisms)
+* refine the concept of "uniquely identified by a physical address" in a system
+
 
 At minimum, the configuration structure needs to describe the two cache block
 sizes and the supported CBIE values.

--- a/cmobase/extensions.adoc
+++ b/cmobase/extensions.adoc
@@ -7,14 +7,16 @@ CMO instructions are defined in the following extensions:
 * <<#Zicboz>>
 * <<#Zicbop>>
 
-Cache block management instructions and cache block zero instructions operate on
-the cache block containing the effective address equal to the base address
-specified in _rs1_. Cache block prefetch instructions operate on the cache block
-containing the effective address equal to the sum of the base address specified
-in _rs1_ and a sign-extended offset encoded in the _imm_ field, where
-offset[4:0] shall equal 0b00000. The effective address is translated into a
-corresponding physical address by the translation mechanisms appropriate in the
-effective privilege level.
+Cache block management instructions operate on the cache block containing the
+effective address equal to the base address specified in _rs1_. Cache block zero
+instructions operate on the cache block or naturally aligned power-of-two
+address range equal in length to the cache block size containing the effective
+address equal to the base address specified in _rs1_. Cache block prefetch
+instructions operate on the cache block containing the effective address equal
+to the sum of the base address specified in _rs1_ and a sign-extended offset
+encoded in the _imm_ field, where offset[4:0] shall equal 0b00000. The effective
+address is translated into a corresponding physical address by the translation
+mechanisms appropriate in the effective privilege level.
 
 include::Zicbom.adoc[]
 include::Zicboz.adoc[]

--- a/cmobase/introduction.adoc
+++ b/cmobase/introduction.adoc
@@ -1,9 +1,9 @@
 [#intro,reftext="Introduction"]
 == Introduction
 
-_Cache management operation_ (or _CMO_) instructions perform operations on
-cached copies of data in the memory hierarchy. These instructions are grouped by
-operation into the following instruction classes:
+_Cache management operation_ (or _CMO_) instructions are intended to perform
+operations on cached copies of data in the memory hierarchy. These instructions
+are grouped by operation into the following instruction classes:
 
 * A _management_ instruction manipulates cached copies of data with respect to
   sets of observers
@@ -13,8 +13,8 @@ operation into the following instruction classes:
   location may be accessed in the near future, potentially allocating cached
   copies of data in one or more caches
 
-This document introduces a base set of CMO ISA extensions that operate
-specifically on cache blocks. Each of the above classes of instructions
+This document introduces a base set of CMO ISA extensions that are intended to
+operate specifically on cache blocks. Each of the above classes of instructions
 represents an extension in this specification:
 
 * The _Zicbom_ extension defines a set of cache block management instructions:


### PR DESCRIPTION
Several minor language change proposals against the CMO draft specification 0.5.

These minor changes are mostly intended to avoid inadvertently constraining implementations, and to clarify the intent of the CMO group based on the discussions that have taken place in the group.