### PR TITLE
New textual form

### DIFF
--- a/cmobase/insns/cbo.clean.adoc
+++ b/cmobase/insns/cbo.clean.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Perform a clean operation on a cache block
 
 Mnemonic::
-cbo.clean _base_
+cbo.clean 0(_base_)
 
 Encoding::
 [wavedrom, , svg]

--- a/cmobase/insns/cbo.flush.adoc
+++ b/cmobase/insns/cbo.flush.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Perform a flush operation on a cache block
 
 Mnemonic::
-cbo.flush _base_
+cbo.flush 0(_base_)
 
 Encoding::
 [wavedrom, , svg]

--- a/cmobase/insns/cbo.inval.adoc
+++ b/cmobase/insns/cbo.inval.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Perform an invalidate operation on a cache block
 
 Mnemonic::
-cbo.inval _base_
+cbo.inval 0(_base_)
 
 Encoding::
 [wavedrom, , svg]

--- a/cmobase/insns/cbo.zero.adoc
+++ b/cmobase/insns/cbo.zero.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Store zeros to the full set of bytes corresponding to a cache block
 
 Mnemonic::
-cbo.zero _base_
+cbo.zero 0(_base_)
 
 Encoding::
 [wavedrom, , svg]


### PR DESCRIPTION
This pull request implements new textual form as proposed by @asb.

Here's some backgrounds (see #47):

1. Alex Bradbury (@asb) proposed this new textual form and toolchain coordination was ongoing.
2. Both GNU and LLVM developers seem happy with @asb's new textual form.
3. Tsukasa OI (@a4lg) ― I ― made two patchsets to implement CBO instructions to GNU Binutils (both textual forms; the original one and proposed one) and Nelson Chu merged new proposed textual form into the main branch. If not reverted, proposed textual form will be a part of the next release of GNU Binutils (would be released later in this year).

If document authors are okay with it, please:

* Change reference assembler mnemonics as in this pull request
* Publish updated document as v1.0.x (possibly v1.0.1)