### PR TITLE
When menvcfg.* is 0, the henvcfg.* and senvcfg.* fields may still be written

### DIFF
--- a/cmobase/csr_state.adoc
+++ b/cmobase/csr_state.adoc
@@ -169,5 +169,8 @@ else
 
 --
 
+The CBIE/CBCFE/CBZE fields in each `x{csrname}` register do not affect the
+read and write behavior of the same fields in the other `x{csrname}` registers.
+
 Each `x{csrname}` register is WARL; however, software should determine the legal
 values from the execution environment discovery mechanism.


### PR DESCRIPTION
This is a clarification of the existing specified behavior, as interpreted in the (long) discussion at https://github.com/riscv/riscv-CMOs/issues/73.

The proposed concise text is from @gfavor.  The expanded behavior it describes is:

> `menvcfg.CBIE` has no effect on the values read from the `henvcfg.CBIE` and `senvcfg.CBIE` fields.
> `menvcfg.CBCFE` has no effect on the values read from the `henvcfg.CBCFE` and `senvcfg.CBCFE` fields.
> `menvcfg.CBZE` has no effect on the values read from the `henvcfg.CBZE` and `senvcfg.CBZE` fields.
> 
> `henvcfg.CBIE` has no effect on the value read from the `senvcfg.CBIE` field.
> `henvcfg.CBCFE` has no effect on the value read from the `senvcfg.CBCFE` field.
> `henvcfg.CBZE` has no effect on the value read from the `senvcfg.CBZE` field.